### PR TITLE
Fix #5 by rejecting imagepromise before the are discarded

### DIFF
--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -33,7 +33,7 @@ var cornerstone = (function (cornerstone) {
 
     function purgeCacheIfNecessary()
     {
-        // if max cache size has not been exceded, do nothing
+        // if max cache size has not been exceeded, do nothing
         if(cacheSizeInBytes <= maximumSizeInBytes)
         {
             return;
@@ -58,6 +58,7 @@ var cornerstone = (function (cornerstone) {
             var lastCachedImage = cachedImages[cachedImages.length - 1];
             cacheSizeInBytes -= lastCachedImage.sizeInBytes;
             delete imageCache[lastCachedImage.imageId];
+            lastCachedImage.imagePromise.reject();
             cachedImages.pop();
         }
     }
@@ -77,6 +78,7 @@ var cornerstone = (function (cornerstone) {
         }
 
         var cachedImage = {
+            loaded : false,
             imageId : imageId,
             imagePromise : imagePromise,
             timeStamp : new Date(),
@@ -126,10 +128,12 @@ var cornerstone = (function (cornerstone) {
     }
 
     function purgeCache() {
-        var oldMaximumSizeInBytes = maximumSizeInBytes;
-        maximumSizeInBytes = 0;
-        purgeCacheIfNecessary();
-        maximumSizeInBytes = oldMaximumSizeInBytes;
+        while (cachedImages.length > 0) {
+            var removedCachedImage = cachedImages.pop();
+            delete imageCache[removedCachedImage.imageId];
+            removedCachedImage.imagePromise.reject();
+        }
+        cacheSizeInBytes = 0;
     }
 
     // module exports


### PR DESCRIPTION
Rejecting imagepromise before the are discarded fixes issue #5. The
then() function is never called and the cacheSizeInBytes is not set into
an incoherent state.

purgecache was modified for clarity. The loaded property of cachedImage 
was added because it is used later and a typo was fixed.
