### PR TITLE
Fix for flip / rotation example

### DIFF
--- a/example/flip&rotation/index.html
+++ b/example/flip&rotation/index.html
@@ -85,7 +85,8 @@ In this example,the image can be flipped (Horizontal/Vertical) or rotated (Clock
         });
 
         $('#rRotate').click(function (e) {
-
+            var viewport = cornerstone.getViewport(element);
+            viewport.rotation+=90;
             cornerstone.setViewport(element, viewport);
         });
         


### PR DESCRIPTION
Here's a tiny fix for the flip / rotation example. Nothing was happening when the clockwise rotation button was clicked.
