### PR TITLE
Add a ContentManager API for image loading

### DIFF
--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -8,6 +8,7 @@ import triggerEvent from './triggerEvent.js';
 
 
 const imageLoaders = {};
+const contentManagers = {};
 
 let unknownImageLoader;
 
@@ -65,6 +66,14 @@ export function loadImage (imageId, options) {
   if (imageId === undefined) {
     throw new Error('loadImage: parameter imageId must not be undefined');
   }
+  
+  const colonIndex = imageId.indexOf(':');
+  const scheme = imageId.substring(0, colonIndex);
+  const contentManager = contentManagers[scheme];
+  
+  if (contentManager) {
+    return contentManager.loadImage(imageId, options);
+  }
 
   const imageLoadObject = getImageLoadObject(imageId);
 
@@ -89,6 +98,14 @@ export function loadImage (imageId, options) {
 export function loadAndCacheImage (imageId, options) {
   if (imageId === undefined) {
     throw new Error('loadAndCacheImage: parameter imageId must not be undefined');
+  }
+  
+  const colonIndex = imageId.indexOf(':');
+  const scheme = imageId.substring(0, colonIndex);
+  const contentManager = contentManagers[scheme];
+  
+  if (contentManager) {
+    return contentManager.loadAndCacheImage(imageId, options);
   }
 
   let imageLoadObject = getImageLoadObject(imageId);
@@ -128,4 +145,18 @@ export function registerUnknownImageLoader (imageLoader) {
   unknownImageLoader = imageLoader;
 
   return oldImageLoader;
+}
+
+/**
+ * Registers a content manager that bypasses the imageCache and is expected to implement 
+ * 
+ * loadImage(imageId, options)
+ * loadAndCacheImage(imageId, options)
+ *
+ * @param {String} scheme The scheme to use for this image loader (e.g. 'dicomweb', 'wadouri', 'http')
+ * @param {Object} contentManager Content manager object that implements the load image functions
+ * @returns {void}
+ */
+export function registerContentManager (scheme, contentManager) {
+  contentManagers[scheme] = contentManager;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ export {
   loadImage,
   loadAndCacheImage,
   registerImageLoader,
-  registerUnknownImageLoader
+  registerUnknownImageLoader,
+  registerContentManager
 } from './imageLoader.js';
 
 export { default as invalidate } from './invalidate.js';


### PR DESCRIPTION
Referencing: https://github.com/cornerstonejs/cornerstone/issues/201

This is just a suggestion for a way to bypass the cornerstone imageCache. I kept the API the same on the content manager object so it is expected that a consumer would implement a loadImage method and a loadAndCacheImage method implying that the underlying implementation manage the aspects of caching. 