### PR TITLE
Allow setting initial viewport before displaying image

### DIFF
--- a/src/setViewport.js
+++ b/src/setViewport.js
@@ -9,7 +9,7 @@ const MIN_VIEWPORT_SCALE = 0.0001;
  * Sets/updates viewport of a given enabled element
  *
  * @param {HTMLElement} element - DOM element of the enabled element
- * @param {Viewport} viewport - Object containing the viewport properties
+ * @param {Viewport} [viewport] - Object containing the viewport properties
  * @returns {void}
  */
 export default function (element, viewport) {

--- a/src/setViewport.js
+++ b/src/setViewport.js
@@ -1,3 +1,4 @@
+import getDefaultViewport from './internal/getDefaultViewport.js';
 import { getEnabledElement } from './enabledElements.js';
 import updateImage from './updateImage.js';
 
@@ -5,7 +6,7 @@ const MIN_WINDOW_WIDTH = 0.000001;
 const MIN_VIEWPORT_SCALE = 0.0001;
 
 /**
- * Sets the viewport for an element and corrects invalid values
+ * Sets/updates viewport of a given enabled element
  *
  * @param {HTMLElement} element - DOM element of the enabled element
  * @param {Viewport} viewport - Object containing the viewport properties
@@ -14,25 +15,31 @@ const MIN_VIEWPORT_SCALE = 0.0001;
 export default function (element, viewport) {
   const enabledElement = getEnabledElement(element);
 
-  enabledElement.viewport.translation.x = viewport.translation.x;
-  enabledElement.viewport.translation.y = viewport.translation.y;
-  enabledElement.viewport.voi.windowCenter = viewport.voi.windowCenter;
-  enabledElement.viewport.invert = viewport.invert;
-  enabledElement.viewport.pixelReplication = viewport.pixelReplication;
-  enabledElement.viewport.rotation = viewport.rotation;
-  enabledElement.viewport.hflip = viewport.hflip;
-  enabledElement.viewport.vflip = viewport.vflip;
-  enabledElement.viewport.modalityLUT = viewport.modalityLUT;
-  enabledElement.viewport.voiLUT = viewport.voiLUT;
-  enabledElement.viewport.colormap = viewport.colormap;
-  enabledElement.viewport.labelmap = viewport.labelmap;
+  // If viewport is not already set, start with default and merge new
+  // viewport options later
+  if (enabledElement.viewport === undefined) {
+    enabledElement.viewport = getDefaultViewport(enabledElement.canvas);
+  }
+
+  // Merge viewport
+  if (viewport) {
+    for (const attrname in viewport) {
+      if (viewport[attrname] !== null) {
+        enabledElement.viewport[attrname] = viewport[attrname];
+      }
+    }
+  }
 
   // Prevent window width from being too small (note that values close to zero are valid and can occur with
   // PET images in particular)
-  enabledElement.viewport.voi.windowWidth = Math.max(viewport.voi.windowWidth, MIN_WINDOW_WIDTH);
+  if (enabledElement.viewport.voi.windowWidth) {
+    enabledElement.viewport.voi.windowWidth = Math.max(viewport.voi.windowWidth, MIN_WINDOW_WIDTH);
+  }
 
   // Prevent scale from getting too small
-  enabledElement.viewport.scale = Math.max(viewport.scale, MIN_VIEWPORT_SCALE);
+  if (enabledElement.viewport.scale) {
+    enabledElement.viewport.scale = Math.max(viewport.scale, MIN_VIEWPORT_SCALE);
+  }
 
   // Normalize the rotation value to a positive rotation in degrees
   enabledElement.viewport.rotation %= 360;
@@ -40,6 +47,8 @@ export default function (element, viewport) {
     enabledElement.viewport.rotation += 360;
   }
 
-  // Force the image to be updated since the viewport has been modified
-  updateImage(element);
+  if (enabledElement.image) {
+    // Force the image to be updated since the viewport has been modified
+    updateImage(element);
+  }
 }

--- a/test/setViewport_test.js
+++ b/test/setViewport_test.js
@@ -56,10 +56,13 @@ describe('Set an enabled element\'s viewport', function () {
 
     enable(this.element, options);
 
-    displayImage(this.element, this.image, this.viewport);
   });
 
   it('should apply viewport settings if provided', function () {
+
+    // Act
+    displayImage(this.element, this.image, this.viewport);
+
     const element = this.element;
 
     const newViewport = {
@@ -91,6 +94,10 @@ describe('Set an enabled element\'s viewport', function () {
   });
 
   it('should prevent windowWidth from getting too small', function () {
+
+    // Act
+    displayImage(this.element, this.image, this.viewport);
+
     const element = this.element;
 
     // Arrange
@@ -106,6 +113,10 @@ describe('Set an enabled element\'s viewport', function () {
   });
 
   it('should prevent scale from getting too small', function () {
+
+    // Act
+    displayImage(this.element, this.image, this.viewport);
+
     const element = this.element;
 
     // Arrange
@@ -121,6 +132,10 @@ describe('Set an enabled element\'s viewport', function () {
   });
 
   it('should normalize rotation values above 359 degrees', function () {
+
+    // Act
+    displayImage(this.element, this.image, this.viewport);
+
     const element = this.element;
 
     // Arrange
@@ -136,6 +151,10 @@ describe('Set an enabled element\'s viewport', function () {
   });
 
   it('should normalize rotation values below 0 degrees', function () {
+
+    // Act
+    displayImage(this.element, this.image, this.viewport);
+
     const element = this.element;
 
     // Arrange
@@ -149,6 +168,40 @@ describe('Set an enabled element\'s viewport', function () {
 
     assert.equal(viewport.rotation, 355);
   });
+
+  it('should apply initial viewport settings with no displayed image', function () {
+
+    const element = this.element;
+
+    const newViewport = {
+      scale: 3.0,
+      translation: {
+        x: 2,
+        y: 2
+      },
+      voi: {
+        windowWidth: 11,
+        windowCenter: 16
+      },
+      invert: false,
+      pixelReplication: false,
+      rotation: 91,
+      hflip: false,
+      vflip: false
+    };
+
+    // Act
+    setViewport(element, newViewport);
+    displayImage(this.element, this.image);
+
+    // Assert
+    const viewport = getViewport(element);
+
+    Object.keys(newViewport).forEach((key) => {
+      assert.deepEqual(newViewport[key], viewport[key]);
+    });
+  });
+
 
   afterEach(function () {
     disable(this.element);


### PR DESCRIPTION
Fixes #33.

This change allows setViewport to set viewport on enabled elements with undefined images. Glad to make any changes you'd like, just let me know.