### PR TITLE
Webgl issue210

### DIFF
--- a/src/colors/colormap.js
+++ b/src/colors/colormap.js
@@ -470,7 +470,7 @@ const colormapsData = {
 /**
  *  Generate linearly spaced vectors
 *  http://cens.ioc.ee/local/man/matlab/techdoc/ref/linspace.html
- * @param {Number} a A number representing the first vector  
+ * @param {Number} a A number representing the first vector
  * @param {Number} b A number representing the second vector
  * @param {Number} n The number of linear spaced vectors to generate
  * @returns {Array} An array of points representing linear spaced vectors.
@@ -559,7 +559,7 @@ function searchSorted (inputArray, values) {
  * Interpolation.
  * @param {any} gamma value denotes a "gamma curve" value which adjusts the brightness
  * at the bottom and top of the map.
- * @returns an array "result" where result[x*(N-1)] gives the closest value for
+ * @returns {any[]} an array "result" where result[x*(N-1)] gives the closest value for
  * Values of x between 0 and 1.
  * @memberof Colors
  */

--- a/src/colors/lookupTable.js
+++ b/src/colors/lookupTable.js
@@ -87,7 +87,7 @@ function HSVToRGB (hue, sat, val) {
  * @param {Number} v A double value which table index will be returned.
  * @param {any} p An object that contains the Table "Range", the table "MaxIndex",
  * A "Shift" from first value in the table and the table "Scale" value
- * @returns {Numeber} The mapped index in the table
+ * @returns {Number} The mapped index in the table
  * @memberof Colors
  */
 function linearIndexLookupMain (v, p) {

--- a/src/colors/lookupTable.js
+++ b/src/colors/lookupTable.js
@@ -87,7 +87,7 @@ function HSVToRGB (hue, sat, val) {
  * @param {Number} v A double value which table index will be returned.
  * @param {any} p An object that contains the Table "Range", the table "MaxIndex",
  * A "Shift" from first value in the table and the table "Scale" value
- * @returns The mapped index in the table
+ * @returns {Numeber} The mapped index in the table
  * @memberof Colors
  */
 function linearIndexLookupMain (v, p) {
@@ -205,7 +205,7 @@ class LookupTable {
 
   /**
    * (Not Used) Sets the range of scalars which will be mapped.
-   * @param {Number} start the minimum scalar value in the range 
+   * @param {Number} start the minimum scalar value in the range
    * @param {Number} end the maximum scalar value in the range
    * @returns {void}
    * @memberof Colors
@@ -308,6 +308,8 @@ class LookupTable {
 
   /**
    * Ensures the out-of-range colors (Below range and Above range) are set correctly.
+   * @returns {void}
+   * @memberof Colors
    */
   buildSpecialColors () {
     const numberOfColors = this.NumberOfColors;

--- a/src/webgl/renderer.js
+++ b/src/webgl/renderer.js
@@ -110,24 +110,32 @@ function initWebGL (canvas) {
   return gl;
 }
 
+/**
+ * Returns the image data type as a string representation.
+ * @param {any} image The cornerstone image object
+ * @returns {string} image data type (rgb, iint16, uint16, int8 and uint8)
+ * @memberof WebGLRendering
+ */
 function getImageDataType (image) {
   if (image.color) {
     return 'rgb';
   }
 
-  let datatype = 'int';
+  const pixelData = image.getPixelData();
 
-  if (image.minPixelValue >= 0) {
-    datatype = `u${datatype}`;
+  if (pixelData instanceof Int16Array) {
+    return 'int16';
   }
 
-  if (image.maxPixelValue > 255) {
-    datatype += '16';
-  } else {
-    datatype += '8';
+  if (pixelData instanceof Uint16Array) {
+    return 'uint16';
   }
 
-  return datatype;
+  if (pixelData instanceof Int8Array) {
+    return 'int8';
+  }
+
+  return 'uint8';
 }
 
 function getShaderProgram (image) {


### PR DESCRIPTION
This PR fixes the issue #210

The getImageDataType in the Webgl renderer is now updated to look at the datatype of the image pixel data to make its decision rather than the Min/Max value.