### PR TITLE
Update full canvas in case of colorSpace change

### DIFF
--- a/src/rendering/renderColorImage.js
+++ b/src/rendering/renderColorImage.js
@@ -27,7 +27,9 @@ function getLut (image, viewport) {
 }
 
 function getRenderCanvas (enabledElement, image, invalidated) {
-  if (!enabledElement.renderingTools.renderCanvas) {
+  const canvasWasColor = enabledElement.renderingTools.lastRenderedIsColor === true;
+
+  if (!enabledElement.renderingTools.renderCanvas || !canvasWasColor) {
     enabledElement.renderingTools.renderCanvas = document.createElement('canvas');
   }
 

--- a/src/rendering/renderGrayscaleImage.js
+++ b/src/rendering/renderGrayscaleImage.js
@@ -9,7 +9,9 @@ import initializeRenderCanvas from './initializeRenderCanvas.js';
 import saveLastRendered from './saveLastRendered.js';
 
 function getRenderCanvas (enabledElement, image, invalidated, useAlphaChannel = true) {
-  if (!enabledElement.renderingTools.renderCanvas) {
+  const canvasWasColor = enabledElement.renderingTools.lastRenderedIsColor === true;
+
+  if (!enabledElement.renderingTools.renderCanvas || canvasWasColor) {
     enabledElement.renderingTools.renderCanvas = document.createElement('canvas');
   }
 

--- a/src/rendering/saveLastRendered.js
+++ b/src/rendering/saveLastRendered.js
@@ -1,8 +1,10 @@
 export default function (enabledElement) {
   const imageId = enabledElement.image.imageId;
   const viewport = enabledElement.viewport;
+  const isColor = enabledElement.image.color;
 
   enabledElement.renderingTools.lastRenderedImageId = imageId;
+  enabledElement.renderingTools.lastRenderedIsColor = isColor;
   enabledElement.renderingTools.lastRenderedViewport = {
     windowCenter: viewport.voi.windowCenter,
     windowWidth: viewport.voi.windowWidth,


### PR DESCRIPTION
## Issue
- Loading an image, depending in the colorspace we do not update all canvas, in order to improve performance. 
- Once we load 2 different colorspace images in sequence, we need to proper set the canvas default, and we were not doing that. 

## Solution
- Expose isColor from last rendered image to know if the colorspace has changed
- Once we update the canvas, we check if the colorspace changed and proper deal with canvas, setting the values as default if needed.

