### PR TITLE
Fix all the build warnings in the test folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ addons:
   chrome: stable
 
 node_js:
-  - "node"
+  - "lts/*"
 
 cache:
   yarn: true

--- a/test/canvasToPixel_test.js
+++ b/test/canvasToPixel_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/colors/colormap_test.js
+++ b/test/colors/colormap_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import { getColormap, getColormapsList } from '../../src/colors/colormap.js';
 

--- a/test/colors/lookupTable_test.js
+++ b/test/colors/lookupTable_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 import LookupTable from '../../src/colors/lookupTable.js';
 
 describe('lookupTable class', function () {

--- a/test/coverage_test.js
+++ b/test/coverage_test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import { expect } from 'chai';
+import { expect } from 'chai'; // eslint-disable-line import/extensions
 
 import * as cornerstone from '../src/index.js';
 

--- a/test/disable_test.js
+++ b/test/disable_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import disable from '../src/disable.js';

--- a/test/displayImage_test.js
+++ b/test/displayImage_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/drawInvalidated_test.js
+++ b/test/drawInvalidated_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/draw_test.js
+++ b/test/draw_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/enable_test.js
+++ b/test/enable_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import disable from '../src/disable.js';

--- a/test/falseColorMapping_test.js
+++ b/test/falseColorMapping_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 import { convertImageToFalseColorImage, restoreImage } from '../src/falseColorMapping.js';
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/fitToWindow_test.js
+++ b/test/fitToWindow_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/getImage_test.js
+++ b/test/getImage_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/getPixels_test.js
+++ b/test/getPixels_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/getStoredPixels_test.js
+++ b/test/getStoredPixels_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/getViewport_test.js
+++ b/test/getViewport_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import getViewport from '../src/getViewport.js';

--- a/test/imageCache_test.js
+++ b/test/imageCache_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import { default as imageCache,
   setMaximumSizeBytes,

--- a/test/imageLoader_test.js
+++ b/test/imageLoader_test.js
@@ -1,10 +1,11 @@
 /* eslint-disable no-unused-expressions */
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import { registerImageLoader,
   registerUnknownImageLoader,
   loadImage,
-  loadAndCacheImage } from '../src/index';
+  loadAndCacheImage
+} from '../src/index'; // eslint-disable-line import/extensions
 
 describe('imageLoader registration module', function () {
   beforeEach(function () {

--- a/test/internal/drawComposite_test.js
+++ b/test/internal/drawComposite_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../../src/enable.js';
 import draw from '../../src/draw.js';

--- a/test/internal/generateLutNew_test.js
+++ b/test/internal/generateLutNew_test.js
@@ -1,4 +1,4 @@
-// import { assert } from 'chai';
+// import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import generateLut from '../../src/internal/generateLut.js';
 

--- a/test/internal/generateLut_test.js
+++ b/test/internal/generateLut_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import generateLut from '../../src/internal/generateLut.js';
 

--- a/test/internal/getCanvas_test.js
+++ b/test/internal/getCanvas_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import getCanvas from '../../src/internal/getCanvas.js';
 

--- a/test/internal/getDefaultViewport_test.js
+++ b/test/internal/getDefaultViewport_test.js
@@ -1,5 +1,5 @@
-import { should, assert } from 'chai';
-import getDefaultViewport from '../../src/internal/getDefaultViewport';
+import { should, assert } from 'chai'; // eslint-disable-line import/extensions
+import getDefaultViewport from '../../src/internal/getDefaultViewport.js';
 
 should();
 
@@ -38,7 +38,7 @@ describe('getDefaultViewport', function () {
     it('should return a viewport with defined values and calculated scale value', function () {
       const viewport = getDefaultViewport(this.canvas, this.imageViewport);
 
-      assert.equal(viewport.scale, 0.5); //should take the columnPixelSpacing into consideration and scale down by 1/2
+      assert.equal(viewport.scale, 0.5); // should take the columnPixelSpacing into consideration and scale down by 1/2
       assert.equal(viewport.displayedArea.presentationSizeMode, 'NONE');
       assert.equal(viewport.displayedArea.rowPixelSpacing, this.imageViewport.rowPixelSpacing);
       assert.equal(viewport.displayedArea.columnPixelSpacing, this.imageViewport.columnPixelSpacing);
@@ -61,13 +61,13 @@ describe('getDefaultViewport', function () {
 
       this.imageViewport = {
         width: 100,
-        height: 100,
+        height: 100
       };
     });
 
     it('should be smart to set the default values to 1/1', function () {
       const viewport = getDefaultViewport(this.canvas, this.imageViewport);
-      
+
       assert.equal(viewport.displayedArea.rowPixelSpacing, 1);
       assert.equal(viewport.displayedArea.columnPixelSpacing, 1);
       assert.equal(viewport.scale, 1);

--- a/test/internal/getImageFitScale_test.js
+++ b/test/internal/getImageFitScale_test.js
@@ -1,5 +1,5 @@
-import { should, assert } from 'chai';
-import getImageFitScale from '../../src/internal/getImageFitScale';
+import { should, assert } from 'chai'; // eslint-disable-line import/extensions
+import getImageFitScale from '../../src/internal/getImageFitScale.js';
 
 should();
 

--- a/test/internal/getImageSize_test.js
+++ b/test/internal/getImageSize_test.js
@@ -1,4 +1,4 @@
-import { should, expect } from 'chai';
+import { should, expect } from 'chai'; // eslint-disable-line import/extensions
 
 import getImageSize from '../../src/internal/getImageSize.js';
 
@@ -27,7 +27,7 @@ describe('getImageSize', function () {
     it('should return the image width/height', function () {
       const image = {
         width: 50,
-        height:100
+        height: 100
       };
 
       const imageSizeNoRotationParameter = getImageSize(image);
@@ -42,9 +42,9 @@ describe('getImageSize', function () {
 
   describe('when an image is passed rotated', function () {
     it('should return the image width/height rotated', function () {
-      let image = {
+      const image = {
         width: 50,
-        height:100
+        height: 100
       };
 
       const returnedImageSize = getImageSize(image, 90);

--- a/test/internal/getModalityLUT_test.js
+++ b/test/internal/getModalityLUT_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import getModalityLUT from '../../src/internal/getModalityLUT.js';
 

--- a/test/internal/getVOILut_test.js
+++ b/test/internal/getVOILut_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import getVOILut from '../../src/internal/getVOILut.js';
 

--- a/test/internal/storedColorPixelDataToCanvasImageData_test.js
+++ b/test/internal/storedColorPixelDataToCanvasImageData_test.js
@@ -1,4 +1,4 @@
-import { should } from 'chai';
+import { should } from 'chai'; // eslint-disable-line import/extensions
 import storedColorPixelDataToCanvasImageData from '../../src/internal/storedColorPixelDataToCanvasImageData.js';
 
 should();

--- a/test/internal/storedPixelDataToCanvasImageDataColorLUT_test.js
+++ b/test/internal/storedPixelDataToCanvasImageDataColorLUT_test.js
@@ -1,4 +1,4 @@
-import { should } from 'chai';
+import { should } from 'chai'; // eslint-disable-line import/extensions
 import storedPixelDataToCanvasImageDataColorLUT from '../../src/internal/storedPixelDataToCanvasImageDataColorLUT.js';
 
 should();

--- a/test/internal/storedPixelDataToCanvasImageDataPseudocolorLUT_test.js
+++ b/test/internal/storedPixelDataToCanvasImageDataPseudocolorLUT_test.js
@@ -1,4 +1,4 @@
-import { should } from 'chai';
+import { should } from 'chai'; // eslint-disable-line import/extensions
 import storedPixelDataToCanvasImageDataPseudocolorLUT from '../../src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js';
 
 should();

--- a/test/internal/storedPixelDataToCanvasImageData_test.js
+++ b/test/internal/storedPixelDataToCanvasImageData_test.js
@@ -1,5 +1,4 @@
-// import { assert } from 'chai';
-import { should } from 'chai';
+import { should } from 'chai'; // eslint-disable-line import/extensions
 import storedPixelDataToCanvasImageData from '../../src/internal/storedPixelDataToCanvasImageData.js';
 
 should();

--- a/test/internal/transform_test.js
+++ b/test/internal/transform_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import { Transform } from '../../src/internal/transform.js';
 

--- a/test/invalidateImageId_test.js
+++ b/test/invalidateImageId_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/invalidated_test.js
+++ b/test/invalidated_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/layers_test.js
+++ b/test/layers_test.js
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { assert, expect } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import updateImage from '../src/updateImage.js';

--- a/test/pageToPixel_test.js
+++ b/test/pageToPixel_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/pixelToCanvas_test.js
+++ b/test/pixelToCanvas_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/rendering/renderColorImage_test.js
+++ b/test/rendering/renderColorImage_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../../src/enable.js';
 import displayImage from '../../src/displayImage.js';

--- a/test/reset_test.js
+++ b/test/reset_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/setViewport_test.js
+++ b/test/setViewport_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';

--- a/test/updateImage_test.js
+++ b/test/updateImage_test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert } from 'chai'; // eslint-disable-line import/extensions
 
 import enable from '../src/enable.js';
 import displayImage from '../src/displayImage.js';


### PR DESCRIPTION
1. Added an inline comment to all test units to disable eslint warning import/extensions when importing "chai" package

`// eslint-disable-line import/extensions`

2. Fix any other build warnings.
