### PR TITLE
Deprecated enabledElement.options.colormap option

### DIFF
--- a/src/enabledElements.js
+++ b/src/enabledElements.js
@@ -79,7 +79,7 @@ const enabledElements = [];
  * @property {Array} [origPixelData] - Original pixel data for an image after it has undergone false color mapping
  * @property {ImageStats} [stats] - Statistics for the last redraw of the image
  * @property {Object} cachedLut - Cached Lookup Table for this image.
- * @property {String|Colormap} [colormap] - an optional colormap ID or colormap object (from colors/colormap.js). This will be applied during rendering to convert the image to pseudocolor
+ * @property {String|Colormap} [colormap] - Depreacted. Use viewport.colormap instead. an optional colormap ID or colormap object (from colors/colormap.js). This will be applied during rendering to convert the image to pseudocolor
  * @property {Boolean} [labelmap=false] - whether or not to render this image as a label map (i.e. skip modality and VOI LUT pipelines and use only a color lookup table)
  */
 

--- a/src/rendering/renderLabelMapImage.js
+++ b/src/rendering/renderLabelMapImage.js
@@ -13,8 +13,11 @@ function getRenderCanvas (enabledElement, image, invalidated) {
 
   const renderCanvas = enabledElement.renderingTools.renderCanvas;
 
-  // TODO: Deprecate enabledElement.options.colormap
   let colormap = enabledElement.viewport.colormap || enabledElement.options.colormap;
+
+  if (enabledElement.options.colormap) {
+    console.warn('enabledElement.options.colormap is deprecated. Use enabledElement.viewport.colormap instead');
+  }
 
   if (colormap && (typeof colormap === 'string')) {
     colormap = colors.getColormap(colormap);

--- a/src/rendering/renderPseudoColorImage.js
+++ b/src/rendering/renderPseudoColorImage.js
@@ -14,9 +14,11 @@ function getRenderCanvas (enabledElement, image, invalidated) {
 
   const renderCanvas = enabledElement.renderingTools.renderCanvas;
 
-  // TODO: Deprecate enabledElement.options.colormap
   let colormap = enabledElement.viewport.colormap || enabledElement.options.colormap;
 
+  if (enabledElement.options.colormap) {
+    console.warn('enabledElement.options.colormap is deprecated. Use enabledElement.viewport.colormap instead');
+  }
   if (colormap && (typeof colormap === 'string')) {
     colormap = colors.getColormap(colormap);
   }


### PR DESCRIPTION
I found TODO items in the code to deprecate `enabledElement.options.colormap` options.

This CR basically addresses this.