### PR TITLE
Fix rowPixelSpacing to not be null

### DIFF
--- a/src/internal/getImageFitScale.js
+++ b/src/internal/getImageFitScale.js
@@ -16,8 +16,8 @@ export default function (windowSize, image, rotation = null) {
   validateParameterUndefinedOrNull(image, 'getImageScale: parameter image must not be undefined');
 
   const imageSize = getImageSize(image, rotation);
-  const rowPixelSpacing = image.rowPixelSpacing === undefined ? 1 : image.rowPixelSpacing;
-  const columnPixelSpacing = image.columnPixelSpacing === undefined ? 1 : image.columnPixelSpacing;
+  const rowPixelSpacing = image.rowPixelSpacing || 1;
+  const columnPixelSpacing = image.columnPixelSpacing || 1;
   let verticalRatio = 1;
   let horizontalRatio = 1;
 


### PR DESCRIPTION
In cases where image.rowPixelSpacing is null, it will be assigned null to rowPixelSpacing and logic will fail. I.e. rowPixelSpacing must be a number and different from 0