### PR TITLE
Remove requestAnimationFrame

### DIFF
--- a/src/enable.js
+++ b/src/enable.js
@@ -1,7 +1,5 @@
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
-import drawImageSync from './internal/drawImageSync.js';
-import requestAnimationFrame from './internal/requestAnimationFrame.js';
 import tryEnableWebgl from './internal/tryEnableWebgl.js';
 import triggerEvent from './triggerEvent.js';
 import generateUUID from './generateUUID.js';
@@ -12,18 +10,6 @@ import getCanvas from './internal/getCanvas.js';
  * @module Enable
  * This module is responsible for enabling an element to display images with cornerstone
  */
-
-/**
- * Returns whether or not an Enabled Element has either a currently active image or
- * a non-empty Array of Enabled Element Layers.
- *
- * @param {EnabledElement} enabledElement An Enabled Element
- * @return {Boolean} Whether or not the Enabled Element has an active image or valid set of layers
- * @memberof Enable
- */
-function hasImageOrLayers (enabledElement) {
-  return enabledElement.image !== undefined || enabledElement.layers.length > 0;
-}
 
 /**
  * Enable an HTML Element for use in Cornerstone
@@ -61,7 +47,6 @@ export default function (element, options) {
     canvas,
     image: undefined, // Will be set once image is loaded
     invalid: false, // True if image needs to be drawn, false if not
-    needsRedraw: true,
     options,
     layers: [],
     data: {},
@@ -74,32 +59,4 @@ export default function (element, options) {
   triggerEvent(events, EVENTS.ELEMENT_ENABLED, enabledElement);
 
   resize(element, true);
-
-  /**
-   * Draw the image immediately
-   *
-   * @param {DOMHighResTimeStamp} timestamp The current time for when requestAnimationFrame starts to fire callbacks
-   * @returns {void}
-   * @memberof Drawing
-   */
-  function draw (timestamp) {
-    if (enabledElement.canvas === undefined) {
-      return;
-    }
-
-    const eventDetails = {
-      enabledElement,
-      timestamp
-    };
-
-    triggerEvent(enabledElement.element, EVENTS.PRE_RENDER, eventDetails);
-
-    if (enabledElement.needsRedraw && hasImageOrLayers(enabledElement)) {
-      drawImageSync(enabledElement, enabledElement.invalid);
-    }
-
-    requestAnimationFrame(draw);
-  }
-
-  draw();
 }

--- a/src/internal/drawImage.js
+++ b/src/internal/drawImage.js
@@ -1,3 +1,5 @@
+import drawImageAsync from './drawImageAsync.js'; // VOYAGER
+
 /**
  * Internal API function to draw an image to a given enabled element
  *
@@ -7,8 +9,9 @@
  * @memberof Internal
  */
 export default function (enabledElement, invalidated = false) {
-  enabledElement.needsRedraw = true;
   if (invalidated) {
     enabledElement.invalid = true;
   }
+
+  drawImageAsync(enabledElement); 
 }

--- a/src/internal/drawImage.js
+++ b/src/internal/drawImage.js
@@ -1,4 +1,4 @@
-import drawImageAsync from './drawImageAsync.js'; // VOYAGER
+import drawImageAsync from './drawImageAsync.js';
 
 /**
  * Internal API function to draw an image to a given enabled element

--- a/src/internal/drawImageAsync.js
+++ b/src/internal/drawImageAsync.js
@@ -1,0 +1,211 @@
+import triggerEvent from '../triggerEvent.js';
+import EVENTS from '../events.js';
+import drawImageSync from './drawImageSync.js';
+
+const throttledDrawImageWait = 1000 / 60;
+// map an view element to a throttled DrawImage function
+const throttledDrawImageMap = new Map(); 
+
+function drawImageUnthrottled (enabledElement) {
+  const eventDetails = {
+    enabledElement,
+    timestamp: performance.now()
+  };
+
+  triggerEvent(enabledElement.element, EVENTS.PRE_RENDER, eventDetails);
+
+  if (enabledElement && enabledElement.canvas && (enabledElement.image || enabledElement.layers.length > 0)) {
+    drawImageSync(enabledElement, enabledElement.invalid);
+  }
+}
+
+
+/**
+ * Draw an image to a given enabled element asynchronously and throttled
+ *
+ * @param {EnabledElement} enabledElement An enabled element to draw into
+ * @returns {void}
+ * @memberof Internal
+ */
+export default function drawImageAsync (enabledElement) {
+  if (enabledElement === undefined) {
+    return;
+  }
+
+  let throttledDrawImage = throttledDrawImageMap.get(enabledElement.element);
+
+  if (!throttledDrawImage) {
+    throttledDrawImage = throttle(drawImageUnthrottled, throttledDrawImageWait);
+    throttledDrawImageMap.set(enabledElement.element, throttledDrawImage);
+  }
+
+  throttledDrawImage(enabledElement);
+}
+
+/* eslint-disable */
+
+/* Creates a debounced function that delays invoking `func` until after `wait`
+	 * milliseconds have elapsed since the last time the debounced function was
+	 * invoked. The debounced function comes with a `cancel` method to cancel
+	 * delayed `func` invocations and a `flush` method to immediately invoke them.
+	 * Provide `options` to indicate whether `func` should be invoked on the
+	 * leading and/or trailing edge of the `wait` timeout. The `func` is invoked
+	 * with the last arguments provided to the debounced function. Subsequent
+	 * calls to the debounced function return the result of the last `func`
+	 * invocation.
+	 *
+	 * **Note:** If `leading` and `trailing` options are `true`, `func` is
+	 * invoked on the trailing edge of the timeout only if the debounced function
+	 * is invoked more than once during the `wait` timeout.
+	 *
+	 * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+	 * until to the next tick, similar to `setTimeout` with a timeout of `0`.
+	 *
+	 * from lodash - https://github.com/lodash/lodash/blob/4.16.2/lodash.js#L10218
+	 */
+function debounce(func, wait, options) {
+  if (!options) options = {};
+
+  let lastArgs, lastThis, maxWait, result, timerId, lastCallTime, lastInvokeTime = 0,
+    leading = false,
+    maxing = false,
+    trailing = true;
+
+  wait = wait || 0;
+  leading = !!options.leading;
+  maxing = 'maxWait' in options;
+  maxWait = maxing ? Math.max(options.maxWait || 0, wait) : maxWait;
+  trailing = 'trailing' in options ? !!options.trailing : trailing;
+
+  function invokeFunc(time) {
+    const args = lastArgs,
+      thisArg = lastThis;
+
+    lastArgs = lastThis = undefined;
+    lastInvokeTime = time;
+    result = func.apply(thisArg, args);
+    return result;
+  }
+
+  function leadingEdge(time) {
+    // Reset any `maxWait` timer.
+    lastInvokeTime = time;
+    // Start the timer for the trailing edge.
+    timerId = setTimeout(timerExpired, wait);
+    // Invoke the leading edge.
+    return leading ? invokeFunc(time) : result;
+  }
+
+  function remainingWait(time) {
+    const timeSinceLastCall = time - lastCallTime,
+      timeSinceLastInvoke = time - lastInvokeTime,
+      result = wait - timeSinceLastCall;
+
+    return maxing ? Math.min(result, maxWait - timeSinceLastInvoke) : result;
+  }
+
+  function shouldInvoke(time) {
+    const timeSinceLastCall = time - lastCallTime,
+      timeSinceLastInvoke = time - lastInvokeTime;
+
+    // Either this is the first call, activity has stopped and we're at the
+    // trailing edge, the system time has gone backwards and we're treating
+    // it as the trailing edge, or we've hit the `maxWait` limit.
+    return (lastCallTime === undefined || (timeSinceLastCall >= wait) ||
+      (timeSinceLastCall < 0) || (maxing && timeSinceLastInvoke >= maxWait));
+  }
+
+  function timerExpired() {
+    const time = Date.now();
+    if (shouldInvoke(time)) {
+      return trailingEdge(time);
+    }
+    // Restart the timer.
+    timerId = setTimeout(timerExpired, remainingWait(time));
+  }
+
+  function trailingEdge(time) {
+    timerId = undefined;
+
+    // Only invoke if we have `lastArgs` which means `func` has been
+    // debounced at least once.
+    if (trailing && lastArgs) {
+      return invokeFunc(time);
+    }
+    lastArgs = lastThis = undefined;
+    return result;
+  }
+
+  function cancel() {
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+    lastInvokeTime = 0;
+    lastArgs = lastCallTime = lastThis = timerId = undefined;
+  }
+
+  function flush() {
+    return timerId === undefined ? result : trailingEdge(Date.now());
+  }
+
+  function debounced(...args) {
+    const time = Date.now(),
+      isInvoking = shouldInvoke(time);
+
+    lastArgs = args;
+    lastThis = this;
+    lastCallTime = time;
+
+    if (isInvoking) {
+      if (timerId === undefined) {
+        return leadingEdge(lastCallTime);
+      }
+      if (maxing) {
+        // Handle invocations in a tight loop.
+        timerId = setTimeout(timerExpired, wait);
+        return invokeFunc(lastCallTime);
+      }
+    }
+    if (timerId === undefined) {
+      timerId = setTimeout(timerExpired, wait);
+    }
+    return result;
+  }
+  debounced.cancel = cancel;
+  debounced.flush = flush;
+  return debounced;
+}
+
+
+/* Creates a throttled function that only invokes `func` at most once per
+ * every `wait` milliseconds. The throttled function comes with a `cancel`
+ * method to cancel delayed `func` invocations and a `flush` method to
+ * immediately invoke them. Provide `options` to indicate whether `func`
+ * should be invoked on the leading and/or trailing edge of the `wait`
+ * timeout. The `func` is invoked with the last arguments provided to the
+ * throttled function. Subsequent calls to the throttled function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the throttled function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until to the next tick, similar to `setTimeout` with a timeout of `0`.
+*/
+function throttle(func, wait, options) {
+  if (!options) options = {};
+  let leading = true,
+    trailing = true;
+
+  leading = 'leading' in options ? !!options.leading : leading;
+  trailing = 'trailing' in options ? !!options.trailing : trailing;
+
+  return debounce(func, wait, {
+    'leading': leading,
+    'maxWait': wait,
+    'trailing': trailing
+  });
+}
+
+/* eslint-enable */

--- a/src/internal/drawImageSync.js
+++ b/src/internal/drawImageSync.js
@@ -73,7 +73,6 @@ export default function (enabledElement, invalidated) {
   image.stats.lastRenderTime = renderTimeInMs;
 
   enabledElement.invalid = false;
-  enabledElement.needsRedraw = false;
 
   triggerEvent(element, EVENTS.IMAGE_RENDERED, eventData);
 }

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -1,6 +1,7 @@
 import { getEnabledElement } from './enabledElements.js';
 import triggerEvent from './triggerEvent.js';
 import EVENTS from './events.js';
+import drawImageAsync from './internal/drawImageAsync.js';
 
 /**
  * Sets the invalid flag on the enabled element and fire an event
@@ -12,10 +13,11 @@ export default function (element) {
   const enabledElement = getEnabledElement(element);
 
   enabledElement.invalid = true;
-  enabledElement.needsRedraw = true;
   const eventData = {
     element
   };
 
   triggerEvent(element, EVENTS.INVALIDATED, eventData);
+
+  drawImageAsync(element);
 }


### PR DESCRIPTION
Solves https://github.com/cornerstonejs/cornerstone/issues/276

Currently Cornerstone `draw` function is called using `requestAnimationFrame` that is 60 times a second (see 
https://github.com/cornerstonejs/cornerstone/blob/master/src/enable.js#L77-#L94)

This is unneeded is very inefficient, draw should only be called once per need  which is what this PR ensures.

Further, `drawImageSync` is now throttled so that if multiple calls to draw the same element arrive within 1000/60 ms only the last one will be executed.

