### PR TITLE
Trigger NEW_IMAGE event *after* enabledElement has been updated

### DIFF
--- a/src/displayImage.js
+++ b/src/displayImage.js
@@ -66,7 +66,8 @@ export default function (element, image, viewport) {
     frameRate
   };
 
+  updateImage(element);
+
   triggerEvent(enabledElement.element, EVENTS.NEW_IMAGE, newImageEventData);
 
-  updateImage(element);
 }


### PR DESCRIPTION
coses https://github.com/cornerstonejs/cornerstone/issues/275

In general, external code want to know when a new image is displayed not 'just before' ... case in point - I am using the cornerstonenewimage event to show/remove an hourglass while an image is displayed and this causes the hourglass to be removed before the image is displayed (which happens a short while after, timing depending on decompressing/drawing times etc) which gives a poor user experience.

This PR moves the triggerEvent line to after the call to updateImage.