### PR TITLE
Enhance RAF

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -1,5 +1,5 @@
 import { getEnabledElement } from './enabledElements.js';
-import drawImage from './internal/drawImage.js';
+import { drawImage } from './internal/drawImage.js';
 
 /**
  * Immediately draws the enabled element

--- a/src/drawInvalidated.js
+++ b/src/drawInvalidated.js
@@ -3,7 +3,7 @@
  */
 
 import { getEnabledElements } from './enabledElements.js';
-import drawImage from './internal/drawImage.js';
+import { drawImage } from './internal/drawImage.js';
 
 /**
  * Draws all invalidated enabled elements and clears the invalid flag after drawing it

--- a/src/enable.js
+++ b/src/enable.js
@@ -1,7 +1,5 @@
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
-import drawImageSync from './internal/drawImageSync.js';
-import requestAnimationFrame from './internal/requestAnimationFrame.js';
 import tryEnableWebgl from './internal/tryEnableWebgl.js';
 import triggerEvent from './triggerEvent.js';
 import generateUUID from './generateUUID.js';
@@ -12,18 +10,6 @@ import getCanvas from './internal/getCanvas.js';
  * @module Enable
  * This module is responsible for enabling an element to display images with cornerstone
  */
-
-/**
- * Returns whether or not an Enabled Element has either a currently active image or
- * a non-empty Array of Enabled Element Layers.
- *
- * @param {EnabledElement} enabledElement An Enabled Element
- * @return {Boolean} Whether or not the Enabled Element has an active image or valid set of layers
- * @memberof Enable
- */
-function hasImageOrLayers (enabledElement) {
-  return enabledElement.image !== undefined || enabledElement.layers.length > 0;
-}
 
 /**
  * Enable an HTML Element for use in Cornerstone
@@ -61,7 +47,6 @@ export default function (element, options) {
     canvas,
     image: undefined, // Will be set once image is loaded
     invalid: false, // True if image needs to be drawn, false if not
-    needsRedraw: true,
     options,
     layers: [],
     data: {},
@@ -74,32 +59,4 @@ export default function (element, options) {
   triggerEvent(events, EVENTS.ELEMENT_ENABLED, enabledElement);
 
   resize(element, true);
-
-  /**
-   * Draw the image immediately
-   *
-   * @param {DOMHighResTimeStamp} timestamp The current time for when requestAnimationFrame starts to fire callbacks
-   * @returns {void}
-   * @memberof Drawing
-   */
-  function draw (timestamp) {
-    if (enabledElement.canvas === undefined) {
-      return;
-    }
-
-    const eventDetails = {
-      enabledElement,
-      timestamp
-    };
-
-    triggerEvent(enabledElement.element, EVENTS.PRE_RENDER, eventDetails);
-
-    if (enabledElement.needsRedraw && hasImageOrLayers(enabledElement)) {
-      drawImageSync(enabledElement, enabledElement.invalid);
-    }
-
-    requestAnimationFrame(draw);
-  }
-
-  draw();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 // Internal (some of these are from old internal/legacy expose)
-import { default as drawImage } from './internal/drawImage.js';
+import { 
+  drawImage, 
+  addDrawCallback, 
+  deleteDrawCallback 
+} from './internal/drawImage.js';
+
 import { default as generateLut } from './internal/generateLut.js';
 import { default as getDefaultViewport } from './internal/getDefaultViewport.js';
 import { default as requestAnimationFrame } from './internal/requestAnimationFrame.js';

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,8 @@ import { default as triggerEvent } from './triggerEvent.js';
 
 const cornerstone = {
   drawImage,
+  addDrawCallback, 
+  deleteDrawCallback, 
   generateLut,
   getDefaultViewport,
   requestAnimationFrame,
@@ -165,6 +167,8 @@ const cornerstone = {
 
 export {
   drawImage,
+  addDrawCallback, 
+  deleteDrawCallback, 
   generateLut,
   getDefaultViewport,
   requestAnimationFrame,

--- a/src/internal/drawImage.js
+++ b/src/internal/drawImage.js
@@ -1,3 +1,14 @@
+import triggerEvent from '../triggerEvent.js';
+import EVENTS from '../events.js';
+import drawImageSync from './drawImageSync.js';
+import requestAnimationFrame from './requestAnimationFrame.js';
+import { getEnabledElement } from '../enabledElements.js';
+
+let rafId = null;
+let rafStopTime = null;
+const map = new Map();
+
+
 /**
  * Internal API function to draw an image to a given enabled element
  *
@@ -6,9 +17,169 @@
  * @returns {void}
  * @memberof Internal
  */
-export default function (enabledElement, invalidated = false) {
-  enabledElement.needsRedraw = true;
+export function drawImage (enabledElement, invalidated = false) {
+  registerVisibilityChange();
+
+  if (!enabledElement || !enabledElement.canvas || (!enabledElement.image && enabledElement.layers.length < 1)) {
+    return;
+  }
+  
+  const element = enabledElement.element;
+  
   if (invalidated) {
     enabledElement.invalid = true;
   }
+
+  if (!map.has(element)) {
+    map.set(element, { 
+      needsRedraw: false, 
+      callbacks: new Set()
+    });
+  }
+
+  map.get(element).needsRedraw = true;
+
+  rafStopTime = performance.now() + 100;
+  if (!rafId) {
+    rafId = requestAnimationFrame(step);
+  }
+}
+
+function step () {
+  map.forEach((entry, element) => {
+    if (!element || !entry || !entry.needsRedraw) {
+      return;
+    }
+    
+    const hasCallbacks = entry.callbacks.size > 0;
+    
+    entry.needsRedraw = hasCallbacks;
+
+    let enabledElement;
+
+    try { 
+      enabledElement = getEnabledElement(element); 
+    } catch (err) { 
+      return; 
+    }
+    
+    const eventDetails = {
+      enabledElement,
+      timestamp: Date.now()
+    };
+    
+    triggerEvent(element, EVENTS.PRE_RENDER, eventDetails);
+    
+    drawImageSync(enabledElement, enabledElement.invalid);
+
+    if (hasCallbacks) {
+      entry.callbacks.forEach((rafcb) => {
+        try {
+          rafcb(enabledElement);
+        } catch (err) {
+          // swallow
+        }
+      });
+      rafStopTime = performance.now() + 100; 
+    }
+  });
+  
+  if (rafStopTime && performance.now() < rafStopTime) {
+    rafId = requestAnimationFrame(step);
+  } else {
+    stopRaf();
+  }
+}
+
+
+/**
+ * add a callback to be called on every RequestAnimationFrame step
+ *
+ * @param {HTMLElement} element The Cornerstone element for this callback
+ * @param {Function} f The callback to call, will be called with the enabled cornerstone element
+ * @returns {void}
+ * @memberof Internal
+ */
+export function addDrawCallback (element, f) {
+  if (!element) {
+    return;
+  }
+  if (!map.has(element)) {
+    map.set(element, { 
+      needsRedraw: false, 
+      callbacks: new Set()
+    });
+  }
+
+  map.get(element).callbacks.add(f);
+}
+
+
+/**
+ * delete a callback that was added with addDrawCallback
+ *
+ * @param {HTMLElement} element The Cornerstone element for this callback
+ * @param {Function} f The callback to delete
+ * @returns {void}
+ * @memberof Internal
+ */
+export function deleteDrawCallback (element, f) {
+  if (!element) {
+    return;
+  }
+  const entry = map.get(element);
+  
+  if (!entry) {
+    return;
+  }
+  entry.callbacks.delete(f);
+}
+
+
+function registerVisibilityChange () {
+  if (registerVisibilityChange.registered) {
+    return;
+  }
+  registerVisibilityChange.registered = true;
+
+  // Set the name of the hidden property and the change event for visibility
+  let hidden, visibilityChange; 
+
+  if (typeof document.hidden !== 'undefined') { // Opera 12.10 and Firefox 18 and later support 
+    hidden = 'hidden';
+    visibilityChange = 'visibilitychange';
+  } else if (typeof document.msHidden !== 'undefined') {
+    hidden = 'msHidden';
+    visibilityChange = 'msvisibilitychange';
+  } else if (typeof document.webkitHidden !== 'undefined') {
+    hidden = 'webkitHidden';
+    visibilityChange = 'webkitvisibilitychange';
+  }  
+
+  if (!hidden || !visibilityChange) {
+    return;
+  }
+  
+  document.addEventListener(visibilityChange, () => {
+    stopRaf();
+  
+    if (!document[hidden]) {
+      rafStopTime = performance.now() + 100;
+      console.log('raf started');
+      rafId = requestAnimationFrame(step);
+    }
+  }, false);
+}
+
+
+function stopRaf () {
+  if (rafId) {
+    try { 
+      cancelAnimationFrame(rafId); 
+    } catch (err) {
+      // swallow
+    }
+  }
+  
+  rafId = null;
 }

--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -1,4 +1,9 @@
-import drawImage from './drawImage.js';
+import { 
+  drawImage, 
+  addDrawCallback, 
+  deleteDrawCallback 
+} from './drawImage.js';
+
 import generateLut from './generateLut.js';
 import getDefaultViewport from './getDefaultViewport.js';
 import requestAnimationFrame from './requestAnimationFrame.js';
@@ -16,6 +21,8 @@ import { Transform } from './transform.js';
  */
 export default {
   drawImage,
+  addDrawCallback, 
+  deleteDrawCallback,
   generateLut,
   getDefaultViewport,
   requestAnimationFrame,

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -1,6 +1,7 @@
 import { getEnabledElement } from './enabledElements.js';
 import triggerEvent from './triggerEvent.js';
 import EVENTS from './events.js';
+import { drawImage } from './internal/drawImage.js';
 
 /**
  * Sets the invalid flag on the enabled element and fire an event
@@ -12,10 +13,11 @@ export default function (element) {
   const enabledElement = getEnabledElement(element);
 
   enabledElement.invalid = true;
-  enabledElement.needsRedraw = true;
   const eventData = {
     element
   };
 
   triggerEvent(element, EVENTS.INVALIDATED, eventData);
+
+  drawImage(element);
 }

--- a/src/invalidateImageId.js
+++ b/src/invalidateImageId.js
@@ -1,5 +1,5 @@
 import { getEnabledElementsByImageId } from './enabledElements.js';
-import drawImage from './internal/drawImage.js';
+import { drawImage } from './internal/drawImage.js';
 
 /**
  * Forces the image to be updated/redrawn for the all enabled elements

--- a/src/updateImage.js
+++ b/src/updateImage.js
@@ -1,5 +1,5 @@
 import { getEnabledElement } from './enabledElements.js';
-import drawImage from './internal/drawImage.js';
+import { drawImage } from './internal/drawImage.js';
 
 /**
  * Forces the image to be updated/redrawn for the specified enabled element


### PR DESCRIPTION
This PR modifies the existing RAF draw mechanism in the following ways:

- use RAF and keep bouncing turning it off so that its not running if nothing needs to be repainted. This allows at both have the advantages of RAF without the cost of having it running when not needed.

- Have only one RAF servicing all elements CS is handling

- add a mechanism to register for callbacks from the RAF (`addDrawCallback` and `deleteDrawCallback`). Tools such as `PlayClip` can now simply register for RAF callback, switch the image on the element and return without needing to maintain their own `setTimeout` mechanisms

- drawImage now registers for the `visibilitychange` HTML event so that ie when a tab that lost focus regains it RAF wil start again

