### PR TITLE
Fixes #411 checks if the  enabledElement.options exists

### DIFF
--- a/src/rendering/renderPseudoColorImage.js
+++ b/src/rendering/renderPseudoColorImage.js
@@ -26,7 +26,7 @@ function getRenderCanvas (enabledElement, image, invalidated) {
 
   let colormap = enabledElement.viewport.colormap || enabledElement.options.colormap;
 
-  if (enabledElement.options.colormap) {
+  if (enabledElement.options && enabledElement.options.colormap) {
     console.warn('enabledElement.options.colormap is deprecated. Use enabledElement.viewport.colormap instead');
   }
   if (colormap && (typeof colormap === 'string')) {


### PR DESCRIPTION
This is a simple fix for the #411 and  #403 issues.

Here is an example of the demo working after the fix: 

![demo-411-new](https://user-images.githubusercontent.com/234049/66125472-681fb980-e5bd-11e9-8f67-0bc2534affac.gif)
