### PR TITLE
Support white fillStyle and responsible to viewport invert

### DIFF
--- a/src/enable.js
+++ b/src/enable.js
@@ -62,7 +62,7 @@ export default function (element, options) {
     image: undefined, // Will be set once image is loaded
     invalid: false, // True if image needs to be drawn, false if not
     needsRedraw: true,
-    options,
+    options: Object.assign({}, options),
     layers: [],
     data: {},
     renderingTools: {},

--- a/src/internal/getFillStyle.js
+++ b/src/internal/getFillStyle.js
@@ -1,0 +1,16 @@
+/**
+ * Get current fillStyle for enabled element
+ *
+ * @param {Object} enabledElement Enabled element
+ * @returns {String} Current fillStyle of enabled element
+ */
+export default function (enabledElement) {
+  const { invert } = enabledElement.viewport || {};
+  const { fillStyle } = enabledElement.options || {};
+
+  if (['black', 'white'].indexOf(fillStyle) !== -1) {
+    return invert ? 'white' : 'black';
+  }
+
+  return 'black';
+}

--- a/src/rendering/renderColorImage.js
+++ b/src/rendering/renderColorImage.js
@@ -1,4 +1,5 @@
 import now from '../internal/now.js';
+import getFillStyle from '../internal/getFillStyle.js';
 import generateColorLut from '../internal/generateColorLut.js';
 import storedColorPixelDataToCanvasImageData from '../internal/storedColorPixelDataToCanvasImageData.js';
 import storedRGBAPixelDataToCanvasImageData from '../internal/storedRGBAPixelDataToCanvasImageData.js';
@@ -127,7 +128,7 @@ export function renderColorImage (enabledElement, invalidated) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   // Clear the canvas
-  context.fillStyle = 'black';
+  context.fillStyle = getFillStyle(enabledElement);
   context.fillRect(0, 0, enabledElement.canvas.width, enabledElement.canvas.height);
 
   // Turn off image smooth/interpolation if pixelReplication is set in the viewport

--- a/src/rendering/renderGrayscaleImage.js
+++ b/src/rendering/renderGrayscaleImage.js
@@ -1,3 +1,4 @@
+import getFillStyle from '../internal/getFillStyle.js';
 import storedPixelDataToCanvasImageData from '../internal/storedPixelDataToCanvasImageData.js';
 import storedPixelDataToCanvasImageDataRGBA from '../internal/storedPixelDataToCanvasImageDataRGBA.js';
 import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
@@ -89,7 +90,7 @@ export function renderGrayscaleImage (enabledElement, invalidated) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   // Clear the canvas
-  context.fillStyle = 'black';
+  context.fillStyle = getFillStyle(enabledElement);
   context.fillRect(0, 0, enabledElement.canvas.width, enabledElement.canvas.height);
 
   // Turn off image smooth/interpolation if pixelReplication is set in the viewport

--- a/src/rendering/renderLabelMapImage.js
+++ b/src/rendering/renderLabelMapImage.js
@@ -1,5 +1,6 @@
 import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
 import now from '../internal/now.js';
+import getFillStyle from '../internal/getFillStyle.js';
 import initializeRenderCanvas from './initializeRenderCanvas.js';
 import saveLastRendered from './saveLastRendered.js';
 import doesImageNeedToBeRendered from './doesImageNeedToBeRendered.js';
@@ -101,7 +102,7 @@ export function renderLabelMapImage (enabledElement, invalidated) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   // Clear the canvas
-  context.fillStyle = 'black';
+  context.fillStyle = getFillStyle(enabledElement);
   context.fillRect(0, 0, enabledElement.canvas.width, enabledElement.canvas.height);
 
   // Turn off image smooth/interpolation if pixelReplication is set in the viewport

--- a/src/rendering/renderPseudoColorImage.js
+++ b/src/rendering/renderPseudoColorImage.js
@@ -1,5 +1,6 @@
 import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
 import now from '../internal/now.js';
+import getFillStyle from '../internal/getFillStyle.js';
 import initializeRenderCanvas from './initializeRenderCanvas.js';
 import getLut from './getLut.js';
 import saveLastRendered from './saveLastRendered.js';
@@ -104,7 +105,7 @@ export function renderPseudoColorImage (enabledElement, invalidated) {
   context.setTransform(1, 0, 0, 1, 0, 0);
 
   // Clear the canvas
-  context.fillStyle = 'black';
+  context.fillStyle = getFillStyle(enabledElement);
   context.fillRect(0, 0, enabledElement.canvas.width, enabledElement.canvas.height);
 
   // Turn off image smooth/interpolation if pixelReplication is set in the viewport


### PR DESCRIPTION
Add a `fillStyle` option to `EnabledElementOptions`.

```ts
interface EnabledElementOptions {
  renderer?: 'webgl';
  fillStyle?: 'black' | 'white';
}
```

If options.fillStyle is not set, the same with default behavior.

```js
context.fillStyle = 'black';
```

If options.fillStyle is set to `white` or `black`, you can set default fillStyle for different element, and the fillStyle will responsible to `viewport.invert`.

```js
const enabledElementOptions = { renderer: 'webgl' };
enabledElementOptions.fillStyle = modality === 'PT' ? 'white' : 'black';
cornerstone.enable(element, enabledElementOptions);
```

![image](https://user-images.githubusercontent.com/1212457/72510452-7059e700-3884-11ea-83ea-4d3547e7d39b.png)

I still have a bug here, I can't figure out it, when I have not set `renderer` to `webgl` and set the `fillStyle` to `white`, the viewport will render to all white.🤔️ I need your help @dannyrb for finishing this PR.

![image](https://user-images.githubusercontent.com/1212457/72510540-941d2d00-3884-11ea-9222-0a8649f4a043.png)

