### PR TITLE
fix #444: self removal of an event listener causing unexpected behavior

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -94,7 +94,7 @@ class EventTarget {
       return true;
     }
 
-    const stack = this.listeners[event.type];
+    const stack = this.listeners[event.type].slice();
 
     for (let i = 0, l = stack.length; i < l; i++) {
       stack[i].call(this, event);

--- a/test/events_test.js
+++ b/test/events_test.js
@@ -1,0 +1,75 @@
+import { assert } from 'chai'; // eslint-disable-line import/extensions
+import { events } from '../src/events.js';
+
+const fakeEventName = 'fake_event';
+
+function clearEventType (eventType) {
+  events.listeners[eventType] = [];
+}
+
+describe('EventTarget', function () {
+  beforeEach(function () {
+    clearEventType(fakeEventName);
+  });
+
+  it('should trigger event properly', function (done) {
+    const expectedEvent = new CustomEvent(fakeEventName, {});
+    let handlerCalled = false;
+
+    function handler (event) {
+      handlerCalled = true;
+      assert.equal(event, expectedEvent);
+    }
+
+    events.addEventListener(fakeEventName, handler);
+    events.dispatchEvent(expectedEvent);
+
+    assert.isTrue(handlerCalled, 'handler should be called');
+    done();
+  });
+
+  it('should not call listener after removal', function (done) {
+    const expectedEvent = new CustomEvent(fakeEventName, {});
+    let handlerCalled = false;
+
+    function handler () {
+      handlerCalled = true;
+    }
+
+    events.addEventListener(fakeEventName, handler);
+    events.removeEventListener(fakeEventName, handler);
+    events.dispatchEvent(expectedEvent);
+
+    assert.isFalse(handlerCalled, 'handler should not be called');
+    done();
+  });
+
+  it('should trigger all listener even if a self-removal happens', function (done) {
+    const expectedEvent = new CustomEvent(fakeEventName, {});
+    let handler1called = false;
+    let handler2called = false;
+    let handler3called = false;
+
+    function handler1 () {
+      handler1called = true;
+    }
+    function handler2 () {
+      handler2called = true;
+      events.removeEventListener(fakeEventName, handler2);
+    }
+    function handler3 () {
+      handler3called = true;
+    }
+
+    events.addEventListener(fakeEventName, handler1);
+    events.addEventListener(fakeEventName, handler2);
+    events.addEventListener(fakeEventName, handler3);
+    events.dispatchEvent(expectedEvent);
+
+    assert.isTrue(handler1called, 'handler1 should be called');
+    assert.isTrue(handler2called, 'handler2 should be called');
+    assert.isTrue(handler3called, 'handler3 should be called');
+
+    done();
+  });
+});


### PR DESCRIPTION
Fix for https://github.com/cornerstonejs/cornerstone/issues/444.

The solution is simply to duplicate the array before running the listeners. This is a common approach in event emitters implementation, and won't cause performance issues because the copy is shallow and most of the time there are only one or a few listeners for each event.
