### PR TITLE
Applying colormap on color images (like ultrasounds)

### DIFF
--- a/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
+++ b/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
@@ -36,14 +36,14 @@ function storedPixelDataToCanvasImageDataPseudocolorLUT (image, grayscaleLut, co
   const grayscalePixelByDefault = () => {
     return pixelData[storedPixelDataIndex++];
   };
-  var grayscalePixelByLuminosityMethod = () => {
-    var r = pixelData[storedPixelDataIndex++];
-    var g = pixelData[storedPixelDataIndex++];
-    var b = pixelData[storedPixelDataIndex++];
+  const grayscalePixelByLuminosityMethod = () => {
+    const r = pixelData[storedPixelDataIndex++];
+    const g = pixelData[storedPixelDataIndex++];
+    const b = pixelData[storedPixelDataIndex++];
     storedPixelDataIndex++;//skip alpha channel
     return Math.round(0.299 * r + 0.587 * g + 0.114 * b);
   };
-  var grayscalePixel = image.color
+  const grayscalePixel = image.color
     ? grayscalePixelByLuminosityMethod
     : grayscalePixelByDefault;
 

--- a/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
+++ b/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
@@ -35,7 +35,10 @@ function storedPixelDataToCanvasImageDataPseudocolorLUT (image, grayscaleLut, co
 
   if (minPixelValue < 0) {
     while (storedPixelDataIndex < numPixels) {
-      grayscale = grayscaleLut[pixelData[storedPixelDataIndex++] + (-minPixelValue)];
+      grayscale = grayscaleLut[pixelData[storedPixelDataIndex] - minPixelValue];
+      //Incrementing by 1 pixel only works with original black and white images. RGBA comes in groups of 4 pixels
+      //(same for the else condition below)
+      storedPixelDataIndex += (image.color ? 4 : 1);
       rgba = clut[grayscale];
       canvasImageDataData[canvasImageDataIndex++] = rgba[0];
       canvasImageDataData[canvasImageDataIndex++] = rgba[1];
@@ -44,7 +47,8 @@ function storedPixelDataToCanvasImageDataPseudocolorLUT (image, grayscaleLut, co
     }
   } else {
     while (storedPixelDataIndex < numPixels) {
-      grayscale = grayscaleLut[pixelData[storedPixelDataIndex++]];
+      grayscale = grayscaleLut[pixelData[storedPixelDataIndex]];
+      storedPixelDataIndex += (image.color ? 4 : 1);
       rgba = clut[grayscale];
       canvasImageDataData[canvasImageDataIndex++] = rgba[0];
       canvasImageDataData[canvasImageDataIndex++] = rgba[1];

--- a/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
+++ b/src/internal/storedPixelDataToCanvasImageDataPseudocolorLUT.js
@@ -33,12 +33,23 @@ function storedPixelDataToCanvasImageDataPseudocolorLUT (image, grayscaleLut, co
     clut = colorLut;
   }
 
+  const grayscalePixelByDefault = () => {
+    return pixelData[storedPixelDataIndex++];
+  };
+  var grayscalePixelByLuminosityMethod = () => {
+    var r = pixelData[storedPixelDataIndex++];
+    var g = pixelData[storedPixelDataIndex++];
+    var b = pixelData[storedPixelDataIndex++];
+    storedPixelDataIndex++;//skip alpha channel
+    return Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+  };
+  var grayscalePixel = image.color
+    ? grayscalePixelByLuminosityMethod
+    : grayscalePixelByDefault;
+
   if (minPixelValue < 0) {
     while (storedPixelDataIndex < numPixels) {
-      grayscale = grayscaleLut[pixelData[storedPixelDataIndex] - minPixelValue];
-      //Incrementing by 1 pixel only works with original black and white images. RGBA comes in groups of 4 pixels
-      //(same for the else condition below)
-      storedPixelDataIndex += (image.color ? 4 : 1);
+      grayscale = grayscaleLut[grayscalePixel() - minPixelValue];
       rgba = clut[grayscale];
       canvasImageDataData[canvasImageDataIndex++] = rgba[0];
       canvasImageDataData[canvasImageDataIndex++] = rgba[1];
@@ -47,8 +58,7 @@ function storedPixelDataToCanvasImageDataPseudocolorLUT (image, grayscaleLut, co
     }
   } else {
     while (storedPixelDataIndex < numPixels) {
-      grayscale = grayscaleLut[pixelData[storedPixelDataIndex]];
-      storedPixelDataIndex += (image.color ? 4 : 1);
+      grayscale = grayscaleLut[grayscalePixel()];
       rgba = clut[grayscale];
       canvasImageDataData[canvasImageDataIndex++] = rgba[0];
       canvasImageDataData[canvasImageDataIndex++] = rgba[1];


### PR DESCRIPTION
Hello
First of all, I wanna thank the Cornerstone creators and team in general. For 3 years I've been using this libraries in my work. The documentation and forums also helped me a lot.
There was only one issue I couldn't find an answer for. When applying colormaps to an image in color (mostly ultrasounds), the canvas shows a distorted image (see the attached picture).
![colormap us error](https://user-images.githubusercontent.com/32710701/139599274-59926421-7f91-4091-9333-c897fc7bc538.png)
Recently i made this update to de cornerstone.js file stored in my project assets's and fixed the problem for me.
This pull request is my first ever. I have read the contributor guidelines and hope i am not violating any rules.
Above all, i expect this to be useful.
Any feedback in my pull request will be apreciated.