### PR TITLE
Fix RequestPoolManager sort priority

### DIFF
--- a/src/requestPool/RequestPoolManager.ts
+++ b/src/requestPool/RequestPoolManager.ts
@@ -211,7 +211,7 @@ type AdditionalDetails = {
       const priorities = Object.keys(this.requestPool[type])
         .map(Number)
         .filter((priority) => this.requestPool[type][priority].length)
-        .sort();
+        .sort((a, b) => a - b);
       return priorities;
     }
 


### PR DESCRIPTION
Simple fix to sort the RequestPoolManager priority groups in the correct order.