### PR TITLE
Update config.yml to use older circleci/node sha after recent changes to latest-browsers tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
-      # - restore_cache:
-      #     keys:
-      #       - v1-dependencies-{{ checksum "package.json" }}
-      #       - v1-dependencies-
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: apt-get -f install 
       - puppeteer/install
       - run: npm install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:latest-browsers
+    - image: circleci/node@sha256:a80b0f7d12ed539c1c40dcdc454433a0a690f1972a038b0d4dc85eaa34fb48d8
 
 jobs:
   checkout_code:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
-      - run: apt-get -f install 
+      - run: sudo apt-get -f install 
       - puppeteer/install
       - run: npm install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/repo
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
+      # - restore_cache:
+      #     keys:
+      #       - v1-dependencies-{{ checksum "package.json" }}
+      #       - v1-dependencies-
       - puppeteer/install
       - run: npm install
       - save_cache:


### PR DESCRIPTION
- Update config.yml to use older circleci/node sha after recent changes to latest-browsers tag
- Image used was updated 2 days ago and broke build: https://hub.docker.com/layers/circleci/node/latest-browsers/images/sha256-1f63129b912afbe0a47c1d37878ed638714dae3f32abdc4d35c532299bd0e136?context=explore