### PR TITLE
fix(circleci): update circleci/node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:latest-browsers
+    - image: circleci/node@sha256:a80b0f7d12ed539c1c40dcdc454433a0a690f1972a038b0d4dc85eaa34fb48d8
 
 jobs:
   checkout_code:


### PR DESCRIPTION
- Update config.yml to use older circleci/node sha after recent changes to latest-browsers tag
- Image tag that has been used was updated 2 days ago and broke all builds: https://hub.docker.com/layers/circleci/node/latest-browsers/images/sha256-1f63129b912afbe0a47c1d37878ed638714dae3f32abdc4d35c532299bd0e136?context=explore