### PR TITLE
Update generateLut.js

### DIFF
--- a/src/internal/generateLut.js
+++ b/src/internal/generateLut.js
@@ -34,11 +34,11 @@ export default function (image, windowWidth, windowCenter, invert, modalityLUT, 
 
   if (invert === true) {
     for (let storedValue = minPixelValue; storedValue <= maxPixelValue; storedValue++) {
-      lut[storedValue + (-offset)] = 255 - vlutfn(mlutfn(storedValue));
+      lut[storedValue + (-offset)] = 255 - Math.round(vlutfn(mlutfn(storedValue)));
     }
   } else {
     for (let storedValue = minPixelValue; storedValue <= maxPixelValue; storedValue++) {
-      lut[storedValue + (-offset)] = vlutfn(mlutfn(storedValue));
+      lut[storedValue + (-offset)] = Math.round(vlutfn(mlutfn(storedValue)));
     }
   }
 


### PR DESCRIPTION
After issue on bug described in issue https://github.com/cornerstonejs/cornerstone/issues/559

On Ipad, Mac (Chrome, FF)
After function vlutfn(mlutfn(storedValue)) we got result like 0.99609375 or 1.9921875. Result must be int (variable lut is Uint8ClampedArray). Most of time we got round 0.99609375 to 1 and 1.9921875 to 2. But sometimes we got 0.99609375 to 0 and 1.9921875 to 1.
Math.round fix this problem.