### PR TITLE
 fix: renderColorImage with @Cornerstonejs/dicom-image-loader 

### DIFF
--- a/src/rendering/renderColorImage.js
+++ b/src/rendering/renderColorImage.js
@@ -62,7 +62,8 @@ function getRenderCanvas (enabledElement, image, invalidated) {
   if ((enabledElement.viewport.voi.windowWidth === 255 || enabledElement.viewport.voi.windowWidth === 256) &&
     (enabledElement.viewport.voi.windowCenter === 127 || enabledElement.viewport.voi.windowCenter === 128) &&
     enabledElement.viewport.invert === false &&
-    image.getCanvas && image.getCanvas()
+    image.getCanvas &&
+    image.getCanvas()
   ) {
     return image.getCanvas();
   }

--- a/src/rendering/renderColorImage.js
+++ b/src/rendering/renderColorImage.js
@@ -59,11 +59,10 @@ function getRenderCanvas (enabledElement, image, invalidated) {
 
   // The ww/wc is identity and not inverted - get a canvas with the image rendered into it for
   // Fast drawing
-  if (enabledElement.viewport.voi.windowWidth === 255 &&
-    enabledElement.viewport.voi.windowCenter === 128 &&
+  if ((enabledElement.viewport.voi.windowWidth === 255 || enabledElement.viewport.voi.windowWidth === 256) &&
+    (enabledElement.viewport.voi.windowCenter === 127 || enabledElement.viewport.voi.windowCenter === 128) &&
     enabledElement.viewport.invert === false &&
-    image.getCanvas &&
-    image.getCanvas()
+    image.getCanvas && image.getCanvas()
   ) {
     return image.getCanvas();
   }


### PR DESCRIPTION
with @Cornerstonejs/dicom-image-loader
 colorImage defalut windowWidth:256 windowCenter:128